### PR TITLE
Add support for rerunning the last test command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,18 @@ Destroy a `<type>` with `<name>`.  You can use tab-completion to get find files 
 
 Run the entire test suite.  Tests are run asynchronously through [`vim-dispatch`](https://github.com/tpope/vim-dispatch).
 
+Has a bang version, `:EmberTest!` which spawns a test server (`ember test
+--server`).
+
 ```
 :EmberTestModule
 ```
 
 When run from a buffer containing an Ember test, run only that test.
+
+```
+:EmberTestRerun
+```
+
+Rerun your last test command.  Does not function with `:EmberTest!`.
 

--- a/autoload/ember.vim
+++ b/autoload/ember.vim
@@ -312,6 +312,7 @@ function! ember#Test(bang, ...)
   if a:bang
     call s:makeAndSwitch('ember test --serve')
   else
+    let s:last_spec = "ember test"
     call s:makeAndSwitch('ember test')
   endif
 endfunction
@@ -325,10 +326,17 @@ function! ember#TestModule()
       " Can we infer the module name from the file name?
       echom 'Could not find module name; make sure it is set'
     else
+      let s:last_spec = "ember test --module " . moduleName
       call s:makeAndSwitchTests("ember test --module ", moduleName)
     endif
   else
     echom 'Current buffer is not an Ember test'
+  endif
+endfunction
+
+function! ember#TestRerun()
+  if exists("s:last_spec")
+    call s:makeAndSwitch(s:last_spec)
   endif
 endfunction
 

--- a/doc/ember.txt
+++ b/doc/ember.txt
@@ -110,6 +110,11 @@ Section 2: Commands                                   *ember-commands*
         In this example, the name is 'Unit | Model | example'.
         This should be set by default, but if not, provide one.
 
+:EmberTestRerun                               *ember-:EmberTestRerun*
+
+        Reruns your last test run with vim-ember-cli.
+        Does not function with `:EmberTest!`.
+
 :EmberInstall [addon-name]                       *ember-:EmberInstall*
 
         Install an Ember addon using "ember install [addon-name]"

--- a/plugin/ember.vim
+++ b/plugin/ember.vim
@@ -16,6 +16,7 @@ command! -nargs=+ -complete=customlist,ember#complete_type_and_files_with_dir Em
 command! -nargs=+ -complete=customlist,ember#complete_type_and_files EmberDestroy call ember#Destroy(<f-args>)
 command! -nargs=0 -bang EmberTest call ember#Test(<bang>0)
 command! -nargs=0 EmberTestModule call ember#TestModule()
+command! -nargs=0 EmberTestRerun call ember#TestRerun()
 command! -nargs=* EmberServe call ember#Server(<f-args>)
 command! -nargs=* EmberBuild call ember#Build(<f-args>)
 command! -nargs=1 EmberInstall call ember#InstallAddon(<f-args>)


### PR DESCRIPTION
Drawing inspiration from [vim-test](https://github.com/janko-m/vim-test) and more specifically from this implementation in [vim-rspec](https://github.com/thoughtbot/vim-rspec/blob/85d6c0fbdcec145f1d1073c64c93617578c7619d/plugin/rspec.vim#L35), this request aims to allow the user to rerun their last test command with `:EmberTestRerun`.

I wasn’t sure how to handle the situation where a user’s last command was `:EmberTest!` since a server could be running, so I decided to be explicit about not supporting it.

Also tried to update the help doc (wasn’t sure how to get the helptag working) and the readme.  I’m still pretty new to vimscript/vim plugin authoring.